### PR TITLE
Prevent multiple door selection during animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,13 @@ export default function App() {
 
   const [showInfoPopup, setShowInfoPopup] = useState(false);
   const handleDoorClick = (id: number) => {
-    if (gameOver || doors.find((d) => d.id === id)?.opened || showRules) return;
+    if (
+      gameOver ||
+      doors.find((d) => d.id === id)?.opened ||
+      showRules ||
+      zoomedDoorId !== null
+    )
+      return;
 
     setZoomedDoorId(id);
 


### PR DESCRIPTION
## Summary
- prevent selecting a second door while an animation is active

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1e926a5ec832781c4247e38a19ba5